### PR TITLE
Resolve bug in category list

### DIFF
--- a/category.html
+++ b/category.html
@@ -25,7 +25,7 @@ description: "An archive of posts sorted by categories."
 {% for post in pages_list %}
 {% if post.title != null %}
 {% if group == null or group == post.group %}
-<li><a href="{{ site.url }}{{ post.url }}">{{ post.title }}<span class="entry-date"><time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">{{ post.date | date: "%b %d, %Y" }}</time></a></li>
+<li><a href="{{ post.url }}">{{ post.title }}<span class="entry-date"><time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">{{ post.date | date: "%b %d, %Y" }}</time></a></li>
 {% endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Resolve bug in category list.

The link of posts was wrong. It was with `{{ site.url }}`, this caused error in localhost dev.
