### PR TITLE
Changes to support Jekyll 3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Dependencies
-markdown:            redcarpet
-highlighter:         pygments
+markdown:            kramdown
+highlighter:         rouge
 
 # Permalinks
 #

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,6 @@ gems: [jekyll-paginate]
 #
 # Use of `relative_permalinks` ensures post links from the index work properly.
 permalink:           pretty
-relative_permalinks: true
 
 # Setup
 title:               Naringu

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,9 @@
 markdown:            kramdown
 highlighter:         rouge
 
+# Gems (for Jekyll 3.0)
+gems: [jekyll-paginate]
+
 # Permalinks
 #
 # Use of `relative_permalinks` ensures post links from the index work properly.


### PR DESCRIPTION
Github Pages is now updated with Jekyll 3 --- and there are little changes and upgrades need to be done for this theme to support it. See this [upgrade link](http://jekyllrb.com/docs/upgrading/2-to-3/)

Since this theme is based from Poole, the changes suggested here is the same as per [commits for Hyde](https://github.com/poole/hyde/pull/135). Basically, 3 items: 
1. Disable relative_permalinks as it breaks example content.
2. Adds the missing jekyll-paginate gem to remove the depreciation message.
3. Change markdown and highlighter to use default Jekyll 3 (supported for GitHub Pages) --- kramdown and rouge (instead of pygments and redcarpet).
